### PR TITLE
Add "a!stats" to a!help (in commands page)

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -58,6 +58,10 @@ module.exports = {
                         {
                             name: `${process.env.PREFIX}appel`,
                             value: "Finally, actually starts the game",
+                        },
+                        {
+                            name: `${process.env.PREFIX}stats`,
+                            value: "Shows your stats in the game",
                         }
                     ),
             ];


### PR DESCRIPTION
This should add the "stats" command to the page 3 of the help command, the commands page.
Not tested